### PR TITLE
arm/linux: dtest and CI segfault

### DIFF
--- a/.github/workflows/arm-build.yaml
+++ b/.github/workflows/arm-build.yaml
@@ -49,7 +49,7 @@ jobs:
           version: 1 # Change this to manually bust the cache
 
       - name: LM4F120 Core Tests (WANT_ITC)
-        run: cd arm/mcu/qemu && TIMEOUT=5s make tests
+        run: cd arm/mcu/lm4f120 && TIMEOUT=5s make tests
 
       - name: Build QEMU virt (WANT_ITC)
         run: cd arm/mcu/qemu && WANT_IGNORECASE=1 WANT_ITC=1 make all

--- a/.github/workflows/arm-build.yaml
+++ b/.github/workflows/arm-build.yaml
@@ -39,11 +39,17 @@ jobs:
       - name: Build LM4F120 (TARGET=LM4)
         run: cd arm/mcu/lm4f120 && TARGET=LM4 make all
 
+      - name: Build LM4120 (WANT_IGNORECASE)
+        run: cd arm/mcu/lm4f120 && WANT_IGNORECASE=1 make all
+
       - name: Cache and Install QEMU ARM
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: qemu-system-arm
           version: 1 # Change this to manually bust the cache
+
+      - name: LM4F120 Core Tests (WANT_ITC)
+        run: cd arm/mcu/qemu && TIMEOUT=5s make tests
 
       - name: Build QEMU virt (WANT_ITC)
         run: cd arm/mcu/qemu && WANT_IGNORECASE=1 WANT_ITC=1 make all

--- a/.github/workflows/arm-linux-build.yaml
+++ b/.github/workflows/arm-linux-build.yaml
@@ -33,20 +33,20 @@ jobs:
           make segments
           make sections
 
-      # - name: Cache and Install QEMU USER ARM
-      #   uses: awalsh128/cache-apt-pkgs-action@latest
-      #   with:
-      #     packages: qemu-user-static
-      #     version: 1 # Change this to manually bust the cache
+      - name: Cache and Install QEMU USER ARM
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: qemu-user-static
+          version: 1 # Change this to manually bust the cache
 
-      # - name: QEMU Core Tests
-      #   run: cd arm/mcu/linux && TIMEOUT=5s make tests
+      - name: QEMU Core Tests
+        run: cd arm/mcu/linux && TIMEOUT=5s make tests
 
       - name: Build Linux/RaspPi (WANT_ITC)
-        run: cd arm/mcu/linux && WANT_ITC=1 make all
+        run: cd arm/mcu/linux && WANT_IGNORECASE=1 WANT_ITC=1 make all
 
-      # - name: QEMU Core Tests (WANT_ITC)
-      #   run: cd arm/mcu/linux && TIMEOUT=5s make tests
+      - name: QEMU Core Tests (WANT_ITC)
+        run: cd arm/mcu/linux && TIMEOUT=5s make tests
 
       - name: Update Refcards
         if: github.ref == 'refs/heads/main'

--- a/arm/mcu/linux/Makefile
+++ b/arm/mcu/linux/Makefile
@@ -22,7 +22,7 @@ endif
 # Included after various configuration bits are defined (importantly MCU_LD)
 include $(AMFORTH)/arm/dev/Makefile
 
-LDFLAGS += -z max-page-size=4096
+LDFLAGS += -no-pie -static -z max-page-size=4096
 
 # To run amforth in emulated container you can use a container runtime that supports --platform linux/arm/v7
 # For MacOS check out https://orbstack.dev/ (Free for personal use)

--- a/arm/mcu/linux/amforth.s
+++ b/arm/mcu/linux/amforth.s
@@ -15,6 +15,16 @@ _start:
 
   ldr r0, =PFA_COLD
   bx r0 @ Switch to thumb mode
+
+/*
+  It seems qemu-arm-static really dislikes having a tiny text segment, next to the large forth segment.
+  The small .text section ends up not loading correctly, it is allocated but filled with zeros, thus segfault.
+  It seems allocating a page-worth of bytes in the intervening .data section helps the qemu elf loader work correctly.
+*/
+.data
+.space 0x1000
+.align 8
+
 .thumb
 
 .section amforth, "awx" @ Everything is writeable and executable

--- a/arm/mcu/lm4f120/Makefile
+++ b/arm/mcu/lm4f120/Makefile
@@ -21,7 +21,7 @@ AMFORTH ?= $(shell git rev-parse --show-toplevel)
 include $(AMFORTH)/arm/dev/Makefile
 
 ## Upload bin file to the device
-upload: build/amforth.elf
+upload:
 	lm4flash build/amforth.bin
 
 # QEMU's lm3s6965evb machine is not the LM4F120H5QR (m3 vs m4), but seems to be close enough.

--- a/arm/mcu/ra4m1/Makefile
+++ b/arm/mcu/ra4m1/Makefile
@@ -52,7 +52,7 @@ OPENOCD ?= openocd
 # The touch1200bps often doesn't work, not sure why (check the -boot option maybe?)
 # Double pressing the reset button is reliable.
 ## Upload bin file to the device  
-upload: build/amforth.bin touch1200bps
+upload:
 	touch1200bps/touch1200bps /dev/$(MODEM)
 	$(BOSSAC) --debug --port=$(MODEM) --write build/amforth.bin --reset
 

--- a/core/amforth32.a.ld
+++ b/core/amforth32.a.ld
@@ -1,27 +1,17 @@
 /* SPDX-License-Identifier: GPL-3.0-only */
+/* 
+	This is an older version of the file that does not allocate space
+	for user dictionary sections. This causes segfaults when running amforth
+	on top of a Linux kernel. On the other hand allocating the space
+	slows down qemu startup as it zeroes out the empty allocated spaces;
+	this gets really bad when the memory regions are far apart.
+*/
 
 /* Memory region info */
 PROVIDE( flash.start = ORIGIN(FLASH) );
 PROVIDE( flash.size = LENGTH(FLASH) );
 PROVIDE( ram.start = ORIGIN(RAM) );
 PROVIDE( ram.size = LENGTH(RAM) );
-
-/*
-	Defining our own PHDRS to control the segment permissions and
-	section allocations explicitly. When running amforth on top of
-	linux kernel, the loader often ignores section attributes and
-	looks at the segment headers only.
-*/
-
-PHDRS
-{
-    text    	PT_LOAD FLAGS(5);   /* r-x */
-    data    	PT_LOAD FLAGS(6);   /* rw- */
-    forth   	PT_LOAD FLAGS(7);   /* rwx */
-    forth_ram   PT_LOAD FLAGS(7);   /* rwx */
-	stack 		PT_LOAD FLAGS(6);	/* rw- */
-	forth_pv 	PT_LOAD FLAGS(6);	/* rw- */
-}
 
 SECTIONS
 {
@@ -34,7 +24,7 @@ SECTIONS
 		KEEP(*(SORT_NONE(.init)))
 		. = ALIGN(4);
 		_einit = .;
-	} >FLASH AT>FLASH :text
+	} >FLASH AT>FLASH
 
 	/* Hardware interrupt table */
 
@@ -42,7 +32,7 @@ SECTIONS
 	{
 		*(.vector);
 		. = ALIGN(64);
-	} >FLASH AT>FLASH :text
+	} >FLASH AT>FLASH
 
 	/* C code sections */
 
@@ -57,13 +47,13 @@ SECTIONS
 		*(.rodata*)
 		*(.gnu.linkonce.t.*)
 		. = ALIGN(4);
-	} >FLASH AT>FLASH :text
+	} >FLASH AT>FLASH 
 
 	.fini :
 	{
 		KEEP(*(SORT_NONE(.fini)))
 		. = ALIGN(4);
-	} >FLASH AT>FLASH :text
+	} >FLASH AT>FLASH
 
 	PROVIDE( _etext = . );
 	PROVIDE( _eitcm = . );	
@@ -73,7 +63,7 @@ SECTIONS
 	  PROVIDE_HIDDEN (__preinit_array_start = .);
 	  KEEP (*(.preinit_array))
 	  PROVIDE_HIDDEN (__preinit_array_end = .);
-	} >FLASH AT>FLASH :text
+	} >FLASH AT>FLASH 
 	
 	.init_array     :
 	{
@@ -81,7 +71,7 @@ SECTIONS
 	  KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
 	  KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
 	  PROVIDE_HIDDEN (__init_array_end = .);
-	} >FLASH AT>FLASH :text
+	} >FLASH AT>FLASH 
 	
 	.fini_array     :
 	{
@@ -89,7 +79,7 @@ SECTIONS
 	  KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
 	  KEEP (*(.fini_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .dtors))
 	  PROVIDE_HIDDEN (__fini_array_end = .);
-	} >FLASH AT>FLASH :text
+	} >FLASH AT>FLASH 
 	
 	.ctors          :
 	{
@@ -111,7 +101,7 @@ SECTIONS
 	  KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .ctors))
 	  KEEP (*(SORT(.ctors.*)))
 	  KEEP (*(.ctors))
-	} >FLASH AT>FLASH :text
+	} >FLASH AT>FLASH 
 	
 	.dtors          :
 	{
@@ -120,7 +110,7 @@ SECTIONS
 	  KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .dtors))
 	  KEEP (*(SORT(.dtors.*)))
 	  KEEP (*(.dtors))
-	} >FLASH AT>FLASH :text
+	} >FLASH AT>FLASH 
 
 	/*
 		This is the main AmForth flash section housing all the predefined words.
@@ -132,7 +122,7 @@ SECTIONS
 		*(amforth)
 		*amforth.o(.text .text.*)
 
-	} >FLASH AT>FLASH :forth
+	} >FLASH AT>FLASH
 
 	/*
 		RAM resident code, i.e. code that must run from RAM.
@@ -145,7 +135,7 @@ SECTIONS
 		PROVIDE(RAM_lower_res = . );
 		*(amres)
 		PROVIDE(RAM_upper_res = . );
-	} >RAM AT>FLASH :text
+	} >RAM AT>FLASH
 
 	PROVIDE(RAM_size_res = RAM_upper_res - RAM_lower_res) ;
 	PROVIDE(RAM_stuf_res = SIZEOF(amramres)) ;
@@ -156,14 +146,14 @@ SECTIONS
 		userdict represents the free space used for new words created at runtime in flash (and therefore persistent).
 		It generally occupies the rest of the FLASH memory region. (Tracked by dp.flash)
 	*/
-	userdict (NOLOAD) :
+	userdict :
 	{
 		. = ALIGN(flash_page) ; 
         /* . = ALIGN(MAX(flash_cell,cellsize)) ;  ->page_end zero filled - not erasesd? */
 		PROVIDE( dp0.flash = . );
 		PROVIDE( flash.high = . );
 		PROVIDE( flash.max = ORIGIN(FLASH) + LENGTH(FLASH));
-	} >FLASH AT>FLASH :forth
+	} >FLASH AT>FLASH
 
 	ASSERT(FSH_upper_res <= dp0.flash ,"*ERROR* userdict overlaps amramres")
 
@@ -182,39 +172,24 @@ SECTIONS
 		FILL(0xDEADBEEF); /* fill value MUST match first_boot_marker */
 		. = . + flash_page - 1;
 		BYTE(0); /* seems to be needed to actually get a write */
-	} >FLASH AT>FLASH :forth
+	} >FLASH AT>FLASH
 
 	ASSERT(FSH_upper_res <= first_boot , "*ERROR* first_boot overlaps amramres")
 
-	/*
-		userdict2 is just a continuation of the userdict section but it needs to be split in two
-		to allow for the first_boot section. We need to actually allocate the available memory region,
-		otherwise for linux targets the kernel won't actually map it into the process' memory space
-		and amforth will segfault if that memory is accessed.
-	*/
-	unused_flash = ORIGIN(FLASH) + LENGTH(FLASH) - ADDR(first_boot) - flash_page - csec_size ;
-	userdict2 (NOLOAD) :
-	{
-		/* actually allocate the rest of unused FLASH */
-		. += unused_flash ;
-	} >FLASH AT>FLASH :forth
-
 	/* C data sections */
 
-	/* allocated size for all the C data sections */
-	csec_size = SIZEOF(.dalign) + SIZEOF(.dlalign) + SIZEOF(.data) + SIZEOF(.bss) ;
 
 	.dalign :
 	{
 		. = ALIGN(4);
 		PROVIDE(_data_vma = .);
-	} >RAM AT>FLASH	:data
+	} >RAM AT>FLASH	
 
 	.dlalign :
 	{
 		. = ALIGN(4); 
 		PROVIDE(_data_lma = .);
-	} >FLASH AT>FLASH :data
+	} >FLASH AT>FLASH
 
 	.data :
 	{
@@ -234,7 +209,7 @@ SECTIONS
     	*(.srodata .srodata.*)
     	. = ALIGN(4);
 		PROVIDE( _edata = .);
-	} >RAM AT>FLASH :data
+	} >RAM AT>FLASH
 
 	.bss :
 	{
@@ -248,7 +223,7 @@ SECTIONS
 		. = ALIGN(4);
 		PROVIDE( _ebss = .);
         PROVIDE( ram_ripe = .); /* QEMU */
-	} >RAM AT>FLASH :data
+	} >RAM AT>FLASH
 
 	PROVIDE( _end = _ebss);
 	PROVIDE( end = . );    
@@ -258,7 +233,7 @@ SECTIONS
 	/* The RAM side of amramres section is first */
 
 	/* amramlo contains RAM allocations of all the pre-compiled words */
-    amramlo (NOLOAD) :
+    amramlo :
     {
         . = ALIGN(256) ;
         
@@ -266,7 +241,7 @@ SECTIONS
         . = . + 256 ;
         PROVIDE(RAM_upper_fi = . ) ;
 
-    } >RAM :forth_ram
+    } >RAM
 
 	ASSERT(RAM_upper_res <= RAM_lower_fi ,"*ERROR* amramres and amramlo overlap")
 
@@ -274,15 +249,8 @@ SECTIONS
 		amramhi contains:
 		* RAM pool, where runtime defined flash words allocate RAM (vp)
 		* ram-dictionary where RAM defined words are compiled (dp.ram)
-
-		We want to allocate all remaining RAM between amramlo and .stack for amramhi,
-		thus the stack_start calculation below.
 	*/
-
-    slack = cellsize ;
-	stack_start = ORIGIN(RAM) + LENGTH(RAM) - __stack_size - slack ;
-
-    amramhi (NOLOAD) :
+    amramhi :
     {
         . = ALIGN(4) ;
         
@@ -295,30 +263,22 @@ SECTIONS
         PROVIDE( dp0.ram = . ) ; 
         PROVIDE( HERESTART = . ) ;
 
-		/* 
-			Allocate the remainder of RAM minus the stack for the ram dictionary.
-			We need to actually allocate the available memory region, otherwise for linux targets
-			the kernel won't actually map it into the process' memory space
-			and amforth will segfault if that memory is accessed.
-		*/
-		. = ABSOLUTE(stack_start) - . ;
-
-    } >RAM :forth_ram
+    } > RAM 
 
 	ASSERT(RAM_upper_fi <= vp0 ,"*ERROR* amramlo and amramhi overlap") 
 
 	/* Sections at the high end of RAM */
 
 	/* C stack section */
-
-    .stack stack_start (NOLOAD) :
+    slack = cellsize ;
+    .stack ORIGIN(RAM) + LENGTH(RAM) - __stack_size - slack :
     {
         PROVIDE( _heap_end = . );    
         . = ALIGN(4);
         PROVIDE(_susrstack = . );
         . = . + __stack_size;
         PROVIDE( _eusrstack = .);
-    } >RAM :stack
+    } >RAM
 	PROVIDE( dp.ram.max = ADDR(.stack) - slack );
 
 	/* End of RAM sections */
@@ -356,15 +316,15 @@ SECTIONS
 	/* predefined size of pvalue arenas, use whole PVFLASH. */
 	PROVIDE(pvarena.size = LENGTH(PVFLASH) / 2);
 
-	pvarena1 (NOLOAD) : {
+	pvarena1 : {
 		PROVIDE(pvarena1_lower = . );
 		. = . + pvarena.size;
 		PROVIDE(pvarena1_upper = .);
-	} >PVFLASH :forth_pv
+	} >PVFLASH
 
-	pvarena2 (NOLOAD) : {
+	pvarena2 : {
 		PROVIDE(pvarena2_lower = . );
 		. = . + pvarena.size;
 		PROVIDE(pvarena2_upper = .);
-	} >PVFLASH :forth_pv
+	} >PVFLASH
 }

--- a/core/amforth32.ld
+++ b/core/amforth32.ld
@@ -123,6 +123,19 @@ SECTIONS
 	} >FLASH AT>FLASH :text
 
 	/*
+		RAM resident code, i.e. code that must run from RAM.
+		COLD is responsible for copying the code to RAM at boot.
+		Example is code flash writing code for RA4.
+	*/
+	amramres :
+	{
+		. = ALIGN(4) ;
+		PROVIDE(RAM_lower_res = . );
+		KEEP(*(amres))
+		PROVIDE(RAM_upper_res = . );
+	} >RAM AT>FLASH :forth
+
+	/*
 		This is the main AmForth flash section housing all the predefined words.
 	*/
 	amforth :
@@ -133,19 +146,6 @@ SECTIONS
 		*amforth.o(.text .text.*)
 
 	} >FLASH AT>FLASH :forth
-
-	/*
-		RAM resident code, i.e. code that must run from RAM.
-		COLD is responsible for copying the code to RAM at boot.
-		Example is code flash writing code for RA4.
-	*/
-	amramres :
-	{
-		. = ALIGN(4) ;
-		PROVIDE(RAM_lower_res = . );
-		*(amres)
-		PROVIDE(RAM_upper_res = . );
-	} >RAM AT>FLASH :text
 
 	PROVIDE(RAM_size_res = RAM_upper_res - RAM_lower_res) ;
 	PROVIDE(RAM_stuf_res = SIZEOF(amramres)) ;
@@ -163,7 +163,7 @@ SECTIONS
 		PROVIDE( dp0.flash = . );
 		PROVIDE( flash.high = . );
 		PROVIDE( flash.max = ORIGIN(FLASH) + LENGTH(FLASH));
-	} >FLASH AT>FLASH :forth
+	} >FLASH :forth
 
 	ASSERT(FSH_upper_res <= dp0.flash ,"*ERROR* userdict overlaps amramres")
 
@@ -192,17 +192,16 @@ SECTIONS
 		otherwise for linux targets the kernel won't actually map it into the process' memory space
 		and amforth will segfault if that memory is accessed.
 	*/
-	unused_flash = ORIGIN(FLASH) + LENGTH(FLASH) - ADDR(first_boot) - flash_page - csec_size ;
 	userdict2 (NOLOAD) :
 	{
 		/* actually allocate the rest of unused FLASH */
-		. += unused_flash ;
-	} >FLASH AT>FLASH :forth
+		. = ORIGIN(FLASH) + LENGTH(FLASH) - cdata_size ;
+	} >FLASH :forth
 
 	/* C data sections */
 
 	/* allocated size for all the C data sections */
-	csec_size = SIZEOF(.dalign) + SIZEOF(.dlalign) + SIZEOF(.data) + SIZEOF(.bss) ;
+	cdata_size = SIZEOF(.dalign) + SIZEOF(.dlalign) + SIZEOF(.data) + SIZEOF(.bss) ;
 
 	.dalign :
 	{
@@ -221,12 +220,12 @@ SECTIONS
     	*(.gnu.linkonce.r.*)
     	*(.data .data.*)
     	*(.gnu.linkonce.d.*)
-		. = ALIGN(8);
+		. = ALIGN(4);
     	PROVIDE( __global_pointer$ = . + 0x800 );
     	*(.sdata .sdata.*)
 		*(.sdata2.*)
     	*(.gnu.linkonce.s.*)
-    	. = ALIGN(8);
+    	. = ALIGN(4);
     	*(.srodata.cst16)
     	*(.srodata.cst8)
     	*(.srodata.cst4)

--- a/core/amforth32.ld
+++ b/core/amforth32.ld
@@ -122,6 +122,59 @@ SECTIONS
 	  KEEP (*(.dtors))
 	} >FLASH AT>FLASH :text
 
+	/* C data sections */
+
+	.dalign :
+	{
+		. = ALIGN(4);
+		PROVIDE(_data_vma = .);
+	} >RAM AT>FLASH	:data
+
+	.dlalign :
+	{
+		. = ALIGN(4); 
+		PROVIDE(_data_lma = .);
+	} >FLASH AT>FLASH :data
+
+	.data :
+	{
+    	*(.gnu.linkonce.r.*)
+    	*(.data .data.*)
+    	*(.gnu.linkonce.d.*)
+		. = ALIGN(8);
+    	PROVIDE( __global_pointer$ = . + 0x800 );
+    	*(.sdata .sdata.*)
+		*(.sdata2.*)
+    	*(.gnu.linkonce.s.*)
+    	. = ALIGN(8);
+    	*(.srodata.cst16)
+    	*(.srodata.cst8)
+    	*(.srodata.cst4)
+    	*(.srodata.cst2)
+    	*(.srodata .srodata.*)
+    	. = ALIGN(4);
+		PROVIDE( _edata = .);
+	} >RAM AT>FLASH :data
+
+	.bss :
+	{
+		. = ALIGN(4);
+		PROVIDE( _sbss = .);
+  	    *(.sbss*)
+        *(.gnu.linkonce.sb.*)
+		*(.bss*)
+     	*(.gnu.linkonce.b.*)		
+		*(COMMON*)
+		. = ALIGN(4);
+		PROVIDE( _ebss = .);
+        PROVIDE( ram_ripe = .); /* QEMU */
+	} >RAM AT>FLASH :data
+
+	PROVIDE( _end = _ebss);
+	PROVIDE( end = . );    
+
+	/* AMFORTH SECTIONS */
+
 	/*
 		RAM resident code, i.e. code that must run from RAM.
 		COLD is responsible for copying the code to RAM at boot.
@@ -195,62 +248,8 @@ SECTIONS
 	userdict2 (NOLOAD) :
 	{
 		/* actually allocate the rest of unused FLASH */
-		. = ORIGIN(FLASH) + LENGTH(FLASH) - cdata_size ;
+		. = ORIGIN(FLASH) + LENGTH(FLASH) ;
 	} >FLASH :forth
-
-	/* C data sections */
-
-	/* allocated size for all the C data sections */
-	cdata_size = SIZEOF(.dalign) + SIZEOF(.dlalign) + SIZEOF(.data) + SIZEOF(.bss) ;
-
-	.dalign :
-	{
-		. = ALIGN(4);
-		PROVIDE(_data_vma = .);
-	} >RAM AT>FLASH	:data
-
-	.dlalign :
-	{
-		. = ALIGN(4); 
-		PROVIDE(_data_lma = .);
-	} >FLASH AT>FLASH :data
-
-	.data :
-	{
-    	*(.gnu.linkonce.r.*)
-    	*(.data .data.*)
-    	*(.gnu.linkonce.d.*)
-		. = ALIGN(4);
-    	PROVIDE( __global_pointer$ = . + 0x800 );
-    	*(.sdata .sdata.*)
-		*(.sdata2.*)
-    	*(.gnu.linkonce.s.*)
-    	. = ALIGN(4);
-    	*(.srodata.cst16)
-    	*(.srodata.cst8)
-    	*(.srodata.cst4)
-    	*(.srodata.cst2)
-    	*(.srodata .srodata.*)
-    	. = ALIGN(4);
-		PROVIDE( _edata = .);
-	} >RAM AT>FLASH :data
-
-	.bss :
-	{
-		. = ALIGN(4);
-		PROVIDE( _sbss = .);
-  	    *(.sbss*)
-        *(.gnu.linkonce.sb.*)
-		*(.bss*)
-     	*(.gnu.linkonce.b.*)		
-		*(COMMON*)
-		. = ALIGN(4);
-		PROVIDE( _ebss = .);
-        PROVIDE( ram_ripe = .); /* QEMU */
-	} >RAM AT>FLASH :data
-
-	PROVIDE( _end = _ebss);
-	PROVIDE( end = . );    
 
 	/* AmForth RAM sections */
 

--- a/core/amforth32.ld
+++ b/core/amforth32.ld
@@ -135,6 +135,10 @@ SECTIONS
 		PROVIDE(RAM_upper_res = . );
 	} >RAM AT>FLASH :forth
 
+	PROVIDE(RAM_size_res = RAM_upper_res - RAM_lower_res) ;
+	PROVIDE(FSH_lower_res = LOADADDR(amramres)) ;
+	PROVIDE(FSH_upper_res = LOADADDR(amramres) + SIZEOF(amramres)) ;
+
 	/*
 		This is the main AmForth flash section housing all the predefined words.
 	*/
@@ -147,10 +151,6 @@ SECTIONS
 
 	} >FLASH AT>FLASH :forth
 
-	PROVIDE(RAM_size_res = RAM_upper_res - RAM_lower_res) ;
-	PROVIDE(RAM_stuf_res = SIZEOF(amramres)) ;
-	PROVIDE(FSH_lower_res = LOADADDR(amramres)) ;
-	PROVIDE(FSH_upper_res = LOADADDR(amramres) + SIZEOF(amramres)) ;
 
 	/*
 		userdict represents the free space used for new words created at runtime in flash (and therefore persistent).

--- a/core/config.inc
+++ b/core/config.inc
@@ -27,6 +27,10 @@
 .global rampool_size
 
 
+/* C stack size */
+.equ __stack_size, 2048
+.global __stack_size
+
 /* 
     Flash parameters
 

--- a/core/dev/Makefile
+++ b/core/dev/Makefile
@@ -134,7 +134,7 @@ build/%.hex: build/%.elf
 build/%.bin: build/%.elf
 	@echo "REBUILD $@"
 	@$(OBJCOPY) -O binary $< $@
-	test $(shell wc -c <$@) -lt 100000
+	test `wc -c <$@` -lt 100000
 
 build/%.lst: build/%.elf
 	@echo "REBUILD $@"

--- a/core/dev/Makefile
+++ b/core/dev/Makefile
@@ -89,6 +89,7 @@ help:
 all: config build/amforth.bin build/amforth.hex build/amforth.lst build/amforth.sal build/amforth.sym build/amforth.toc build/amforth.txt build/amforth.html
 	@echo INFO: Built $(TARGET) $(REVISION) using $(TC_DIR)
 	@$(SIZE) build/amforth.elf
+	@cd build && ls -l amforth.bin amforth.hex amforth.elf
 
 
 buildinfo:
@@ -133,6 +134,7 @@ build/%.hex: build/%.elf
 build/%.bin: build/%.elf
 	@echo "REBUILD $@"
 	@$(OBJCOPY) -O binary $< $@
+	test $(shell wc -c <$@) -lt 100000
 
 build/%.lst: build/%.elf
 	@echo "REBUILD $@"

--- a/rv/mcu/hifive1/config.inc
+++ b/rv/mcu/hifive1/config.inc
@@ -4,7 +4,12 @@
 .equ datastack_size, 32 * cellsize
 .equ returnstack_size, 32 * cellsize
 
+.equ rampool_size, 1024 * cellsize
+
 /* TODO: this is made up, needs correcting */ 
 .equ flash_page, 1*1024
 .equ flash_cell, 1
 .equ flash_erased, 0xFFFFFFFF /* a word in erased flash */
+
+/* C stack size */
+.equ __stack_size, 0

--- a/rv/mcu/qemu/Makefile
+++ b/rv/mcu/qemu/Makefile
@@ -26,15 +26,14 @@ include $(AMFORTH)/rv/dev/Makefile
 # 0x8000_0000 no matter what ENTRY() has in the linker file. The cpu-num=0 sets the PC
 # to the value indicated by ENTRY(), which is much more suitable our needs.
 # The alternative option line gives a hint as to how to set the PC to an absolute address at boot time.
-# QEMU := $(QEMU_RV32) -M virt -bios none -device loader,file=build/amforth.elf,cpu-num=0
+QEMU := $(QEMU_RV32) -M virt -bios none -device loader,file=build/amforth.elf,cpu-num=0
 #        -device loader,addr=0x20000000,cpu-num=0
 
 # The above is really slow when the memory regions are far apart, supposedly due to a slow generic ELF loader
 # that is zeroing out a lot of empty memory in an inefficient way. The workaround is to load the bin file instead,
 # which bypasses the ELF loading semantics. Note that it is important to set the loading address correctly,
 # it needs to match the start of the FLASH memory region!
-
-QEMU := $(QEMU_RV32) -M virt -bios none -device loader,file=build/amforth.bin,addr=0x20010000,cpu-num=0
+# QEMU := $(QEMU_RV32) -M virt -bios none -device loader,file=build/amforth.bin,addr=0x20010000,cpu-num=0
 
 ## Start AmForth under QEMU with operator uart connected to stdio
 stdio:

--- a/rv/mcu/qemu/Makefile
+++ b/rv/mcu/qemu/Makefile
@@ -20,14 +20,21 @@ include $(AMFORTH)/rv/dev/Makefile
 .PRECIOUS: amforth.s
 
 #? --- QEM ---
+# QEMU := $(QEMU_RV32) -M virt -bios none -kernel build/amforth.elf
 
 # This is quite different from the -kernel option, which will for the RV 'virt' jump to
 # 0x8000_0000 no matter what ENTRY() has in the linker file. The cpu-num=0 sets the PC
-# to the value indicated by ENTRY(), which is much more suitable our needs. The commented
-# out line gives a hint as to how to set the PC to an absolute address at boot time.
-
-QEMU := $(QEMU_RV32) -M virt -bios none -device loader,file=build/amforth.elf,cpu-num=0
+# to the value indicated by ENTRY(), which is much more suitable our needs.
+# The alternative option line gives a hint as to how to set the PC to an absolute address at boot time.
+# QEMU := $(QEMU_RV32) -M virt -bios none -device loader,file=build/amforth.elf,cpu-num=0
 #        -device loader,addr=0x20000000,cpu-num=0
+
+# The above is really slow when the memory regions are far apart, supposedly due to a slow generic ELF loader
+# that is zeroing out a lot of empty memory in an inefficient way. The workaround is to load the bin file instead,
+# which bypasses the ELF loading semantics. Note that it is important to set the loading address correctly,
+# it needs to match the start of the FLASH memory region!
+
+QEMU := $(QEMU_RV32) -M virt -bios none -device loader,file=build/amforth.bin,addr=0x20010000,cpu-num=0
 
 ## Start AmForth under QEMU with operator uart connected to stdio
 stdio:


### PR DESCRIPTION
So fortunately the CI segfault also reproduced in local Docker, and although that is not exactly a friendly debugging target either (GDB doesn't work in emulated container) I was able to deduce that the issue is that the user dictionary spaces weren't mapped as executable regions. It is possible to get the containerized process to dump the core file (need to invoke `ulimit -c unlimited` first), but the core file can then be analyzed using GDB outside of the container. The segfault was happening in the synthetic jump instruction we compile into DOES> words and is therefore executed in those spaces. 

So, how to mark the memory as executable? We need to mark the memory segments produced by the linker as executable. For that most reasonable way seems to be adding a PHDRS section to the linker file and declaring segments explicitly instead of letting the linker conjure them up, and then assigning each section to a specific segment (the :segment bit at the end of the section definitions).

Coming up with the set of segments was also a journey, because the :segment is only a hint apparently and you need to be careful about making segments span large memory areas and therefore large MemSiz value in the `make segments` output below. It is very easy to end up with a large segment that contains other segments, usually you'll see the same section mapped to multiple segments in that case. What we want is to have nice tidy segments and each section mapped to exactly one of them.

Below is the final arm/linux layout, note that the segments 02 and 03 containing all the forth sections are marked RWE (E = executable). amramhi is what made the tests segfault, but we also want the userdict section executable for >flash compiled words.

```
% make segments             
/opt/homebrew/opt/arm-linux-gnueabihf-binutils/bin/arm-linux-gnueabihf-readelf --segments build/amforth.elf

Elf file type is EXEC (Executable file)
Entry point 0x10000
There are 6 program headers, starting at offset 52

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  LOAD           0x001000 0x00010000 0x00010000 0x00018 0x00018 R E 0x1000
  LOAD           0x00a000 0x10000000 0x0004e000 0x00000 0x010e8 RW  0x1000
  LOAD           0x001018 0x00010018 0x00010018 0x087e8 0x3dfe8 RWE 0x1000
  LOAD           0x0000e8 0x100010e8 0x0004e000 0x00000 0xcc714 RWE 0x1000
  LOAD           0x0007fc 0x100ff7fc 0x100ff7fc 0x00000 0x00800 RW  0x1000
  LOAD           0x001000 0x0004e000 0x0004e000 0x00000 0x02000 RW  0x1000

 Section to Segment mapping:
  Segment Sections...
   00     .text 
   01     .data .bss amramlo 
   02     amforth userdict first_boot userdict2 
   03     amramlo amramhi 
   04     .stack 
   05     pvarena1 pvarena2 
```

Another tweak in amforth32.ld is the addition of `(NOLOAD)` flag to some of the sections, which marks the section as not having any content in the file. It was one of the AI recommendations to deal with the slow load problem on RV qemu, but it didn't help because the issue isn't loading things from file but zeroing out of empty memory and the (NOLOAD) doesn't really affect that. But the sections are marked correctly this way and I figured I may as well leave it there.

Otherwise the actual fix is the change of the `-device loader` to use the `.bin` file instead of the `.elf` file and thus bypassing the ELF loading logic altogether:
```
QEMU := $(QEMU_RV32) -M virt -bios none -device loader,file=build/amforth.bin,addr=0x20010000,cpu-num=0
```

While fussing around with the segments I had to change the way the `amramhi` allocation of the available RAM was done, by moving the `stack_start` computation up and using it in the `amramhi` definition. This triggered a discovery of an issue on hifive which has so little RAM that there wan't enough room for both the default amount of `rampool_size` and `__stack_size`. To solve it I moved `__stack_size` into config.s and reduced both in hifive's config.s so that things could actually fit.

With these fixes I was able to enable the CI tests for arm/linux and things seem to be happy now.

